### PR TITLE
fix: configure netdev when interface is UP but has no real addresses

### DIFF
--- a/internal/drivers/netdev.go
+++ b/internal/drivers/netdev.go
@@ -41,7 +41,7 @@ func EnsureNetDevice(link netlink.Link, eri *types.ERI) error {
 	if err != nil {
 		return err
 	}
-	if link.Attrs().OperState != netlink.OperUp {
+	if link.Attrs().OperState != netlink.OperUp || !hasNonLinkLocalAddr(link) {
 		driverLog.Info("link down, try to up it", "link", link.Attrs().Name)
 		err = ensureUpLink(link)
 		if err != nil {
@@ -232,6 +232,19 @@ func genRoutesForAddr(gateway net.IP, cidr *net.IPNet) ([]*route, error) {
 	defaultRoute.metric = selectMetric(defaultRoute)
 	defaultRoute.gateway = gateway
 	return []*route{cidrRoute, defaultRoute}, nil
+}
+
+func hasNonLinkLocalAddr(link netlink.Link) bool {
+	addrs, err := netlink.AddrList(link, netlink.FAMILY_ALL)
+	if err != nil {
+		return false
+	}
+	for _, addr := range addrs {
+		if !addr.IP.IsLinkLocalUnicast() && !addr.IP.IsLinkLocalMulticast() {
+			return true
+		}
+	}
+	return false
 }
 
 func getNetConfFromMetadata(mac string) (*netConf, error) {


### PR DESCRIPTION
On Ubuntu 24.04, network interfaces can be automatically brought UP even without being managed, leaving them with only link-local IPv6 addresses. The previous check only looked at OperState, causing these interfaces to be skipped entirely.

Now also check whether the interface has any non-link-local addresses. If it's UP but has no real addresses, proceed with normal configuration. If it has non-link-local addresses, it's likely managed by another component and should not be touched.