### PR TITLE
feat: configure MTU for jumbo frame enabled instances via ECS API

### DIFF
--- a/api/v1/erdmadevice_types.go
+++ b/api/v1/erdmadevice_types.go
@@ -38,7 +38,8 @@ type ERdmaDeviceSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// Foo is an example field of ERdmaDevice. Edit erdmadevice_types.go to remove/update
-	Devices []DeviceInfo `json:"devices"`
+	Devices    []DeviceInfo `json:"devices"`
+	JumboFrame bool         `json:"jumboFrame,omitempty"`
 }
 
 const (

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -22,6 +22,7 @@ func main() {
 		localERIDiscovery     bool
 		exposedLocalERIs      string
 		erdmaInstallerVersion string
+		jumboFrameMTU         int
 	)
 	flag.StringVar(&preferDriver, "prefer-driver", "", "prefer driver")
 	flag.BoolVar(&allocAllDevices, "allocate-all-devices", false,
@@ -34,6 +35,8 @@ func main() {
 		"allocate specific ERI from existing ERI to pods for each instance")
 	flag.StringVar(&erdmaInstallerVersion, "erdma-installer-version", "1.5.4",
 		"erdma installer version")
+	flag.IntVar(&jumboFrameMTU, "jumbo-frame-mtu", 8500,
+		"MTU value to set on ERDMA network interfaces when jumbo frame is enabled")
 	flag.Parse()
 
 	eriAgent, err := agent.NewAgent(
@@ -43,6 +46,7 @@ func main() {
 		localERIDiscovery,
 		exposedLocalERIs,
 		erdmaInstallerVersion,
+		jumboFrameMTU,
 	)
 	if err != nil {
 		panic(err)

--- a/config/crd/bases/network.alibabacloud.com_erdmadevices.yaml
+++ b/config/crd/bases/network.alibabacloud.com_erdmadevices.yaml
@@ -58,6 +58,8 @@ spec:
                       type: integer
                   type: object
                 type: array
+              jumboFrame:
+                type: boolean
             required:
             - devices
             type: object

--- a/deploy/helm/templates/customresourcedefinition.yaml
+++ b/deploy/helm/templates/customresourcedefinition.yaml
@@ -58,6 +58,8 @@ spec:
                       type: integer
                   type: object
                 type: array
+              jumboFrame:
+                type: boolean
             required:
             - devices
             type: object

--- a/deploy/helm/templates/daemonset.yaml
+++ b/deploy/helm/templates/daemonset.yaml
@@ -53,6 +53,9 @@ spec:
             {{ if not .Values.config.enableWebhook }}
             - --deviceplugin-prestart-container
             {{ end }}
+            {{ if .Values.agent.jumboFrameMTU }}
+            - --jumbo-frame-mtu={{ .Values.agent.jumboFrameMTU }}
+            {{ end }}
           image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
           env:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -25,6 +25,7 @@ agent:
     tag: "latest"
   preferDriver: ""
   allocateAllDevices: false
+  jumboFrameMTU: 8500
   # format: 
   # expose specific eris for matched node: - <instance_id> <eri-0>/<eri-1>/... 
   # expose specific eris for unmatched node: - i-* <eri-0>/<eri-1>/...

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -29,6 +29,7 @@ type Agent struct {
 	devicepluginPreStart bool
 	localERIDiscovery    bool
 	exposedLocalERIs     []string
+	jumboFrameMTU        int
 }
 
 func stackTriger() {
@@ -54,12 +55,12 @@ func stackTriger() {
 	signal.Notify(sigchain, syscall.SIGUSR1)
 }
 
-func NewAgent(preferDriver string, allocAllDevice bool, devicepluginPreStart bool, localERIDiscovery bool, exposedLocalERIs string, erdmaInstallerVersion string) (*Agent, error) {
+func NewAgent(preferDriver string, allocAllDevice bool, devicepluginPreStart bool, localERIDiscovery bool, exposedLocalERIs string, erdmaInstallerVersion string, jumboFrameMTU int) (*Agent, error) {
 	kubernetes, err := k8s.NewKubernetes()
 	if err != nil {
 		return nil, err
 	}
-	agentLog.Info("NewAgent: ", "localERIDiscovery", localERIDiscovery, "erdmaInstallerVersion", erdmaInstallerVersion)
+	agentLog.Info("NewAgent: ", "localERIDiscovery", localERIDiscovery, "erdmaInstallerVersion", erdmaInstallerVersion, "jumboFrameMTU", jumboFrameMTU)
 	return &Agent{
 		kubernetes:           kubernetes,
 		driver:               drivers.GetDriver(preferDriver, erdmaInstallerVersion),
@@ -67,6 +68,7 @@ func NewAgent(preferDriver string, allocAllDevice bool, devicepluginPreStart boo
 		devicepluginPreStart: devicepluginPreStart,
 		localERIDiscovery:    localERIDiscovery,
 		exposedLocalERIs:     strings.Split(exposedLocalERIs, ","),
+		jumboFrameMTU:        jumboFrameMTU,
 	}, nil
 }
 
@@ -114,11 +116,13 @@ func (a *Agent) Run() error {
 	erdmaDevices := make([]*types.ERdmaDeviceInfo, 0)
 	for _, eriInfo := range eriInfos.Spec.Devices {
 		deviceInfo, err := a.driver.ProbeDevice(&types.ERI{
-			ID:           eriInfo.ID,
-			IsPrimaryENI: eriInfo.IsPrimaryENI,
-			MAC:          eriInfo.MAC,
-			InstanceID:   eriInfo.InstanceID,
-			CardIndex:    eriInfo.NetworkCardIndex,
+			ID:            eriInfo.ID,
+			IsPrimaryENI:  eriInfo.IsPrimaryENI,
+			MAC:           eriInfo.MAC,
+			InstanceID:    eriInfo.InstanceID,
+			CardIndex:     eriInfo.NetworkCardIndex,
+			JumboFrame:    eriInfos.Spec.JumboFrame,
+			JumboFrameMTU: a.jumboFrameMTU,
 		})
 		if err != nil {
 			return fmt.Errorf("probe device failed, err: %v", err)

--- a/internal/controller/eri.go
+++ b/internal/controller/eri.go
@@ -397,6 +397,20 @@ func (e *EriClient) EnsureEriForInstance(devices []networkv1.DeviceInfo) ([]netw
 	return devStatus, nil
 }
 
+func (e *EriClient) IsJumboFrameEnabled(instanceID string) (bool, error) {
+	resp, err := e.client.DescribeInstanceAttribute(&ecs.DescribeInstanceAttributeRequest{
+		InstanceId: ptr.To(instanceID),
+	})
+	if err != nil {
+		return false, fmt.Errorf("cannot describe instance attribute %s: %s", instanceID, err)
+	}
+	return jumboFrameFromAttr(resp.Body.EnableJumboFrame), nil
+}
+
+func jumboFrameFromAttr(enabled *bool) bool {
+	return enabled != nil && *enabled
+}
+
 func (e *EriClient) OwnENI(eni *ecs.DescribeNetworkInterfacesResponseBodyNetworkInterfaceSetsNetworkInterfaceSet) bool {
 	if e.ManagedNonOwned {
 		return true

--- a/internal/controller/eri_jumbo_test.go
+++ b/internal/controller/eri_jumbo_test.go
@@ -1,0 +1,42 @@
+// Copyright 2024 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJumboFrameFromAttr(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	tests := []struct {
+		name     string
+		input    *bool
+		expected bool
+	}{
+		{
+			name:     "nil pointer returns false",
+			input:    nil,
+			expected: false,
+		},
+		{
+			name:     "true pointer returns true",
+			input:    &trueVal,
+			expected: true,
+		},
+		{
+			name:     "false pointer returns false",
+			input:    &falseVal,
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, jumboFrameFromAttr(tt.input))
+		})
+	}
+}

--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -88,6 +88,11 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 			erdmaLogger.Info("node not support erdma", "name", node.Name, "instance-id", instanceID)
 			return ctrl.Result{}, nil
 		}
+		jumboFrame, err := r.EriClient.IsJumboFrameEnabled(instanceID)
+		if err != nil {
+			erdmaLogger.Error(err, "failed to check jumbo frame status, defaulting to false")
+			jumboFrame = false
+		}
 		erdmaDevice := networkv1.ERdmaDevice{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: node.Name,
@@ -105,6 +110,7 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 				},
 			},
 			Spec: networkv1.ERdmaDeviceSpec{
+				JumboFrame: jumboFrame,
 				Devices: lo.Map(eri, func(item *types.ERI, index int) networkv1.DeviceInfo {
 					return networkv1.DeviceInfo{
 						InstanceID:       item.InstanceID,

--- a/internal/drivers/mtu.go
+++ b/internal/drivers/mtu.go
@@ -1,0 +1,14 @@
+package drivers
+
+import "github.com/AliyunContainerService/alibabacloud-erdma-controller/internal/types"
+
+const defaultJumboFrameMTU = 8500
+
+// jumboMTU returns the MTU to use when jumbo frame is enabled.
+// It falls back to defaultJumboFrameMTU when eri.JumboFrameMTU is not set.
+func jumboMTU(eri *types.ERI) int {
+	if eri.JumboFrameMTU > 0 {
+		return eri.JumboFrameMTU
+	}
+	return defaultJumboFrameMTU
+}

--- a/internal/drivers/mtu_test.go
+++ b/internal/drivers/mtu_test.go
@@ -1,0 +1,51 @@
+package drivers
+
+import (
+	"testing"
+
+	"github.com/AliyunContainerService/alibabacloud-erdma-controller/internal/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJumboMTU(t *testing.T) {
+	tests := []struct {
+		name     string
+		eri      *types.ERI
+		expected int
+	}{
+		{
+			name:     "zero JumboFrameMTU falls back to default 8500",
+			eri:      &types.ERI{JumboFrame: true, JumboFrameMTU: 0},
+			expected: 8500,
+		},
+		{
+			name:     "custom JumboFrameMTU is used as-is",
+			eri:      &types.ERI{JumboFrame: true, JumboFrameMTU: 9000},
+			expected: 9000,
+		},
+		{
+			name:     "JumboFrameMTU equal to default is used as-is",
+			eri:      &types.ERI{JumboFrame: true, JumboFrameMTU: 8500},
+			expected: 8500,
+		},
+		{
+			name:     "negative JumboFrameMTU falls back to default",
+			eri:      &types.ERI{JumboFrame: true, JumboFrameMTU: -1},
+			expected: 8500,
+		},
+		{
+			name:     "JumboFrame disabled still returns correct MTU value",
+			eri:      &types.ERI{JumboFrame: false, JumboFrameMTU: 9000},
+			expected: 9000,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, jumboMTU(tt.eri))
+		})
+	}
+}
+
+func TestDefaultJumboFrameMTU(t *testing.T) {
+	assert.Equal(t, 8500, defaultJumboFrameMTU)
+}

--- a/internal/drivers/netdev.go
+++ b/internal/drivers/netdev.go
@@ -41,8 +41,14 @@ func EnsureNetDevice(link netlink.Link, eri *types.ERI) error {
 	if err != nil {
 		return err
 	}
+	mtu := jumboMTU(eri)
 	if link.Attrs().OperState != netlink.OperUp || !hasNonLinkLocalAddr(link) {
 		driverLog.Info("link down, try to up it", "link", link.Attrs().Name)
+		if eri.JumboFrame {
+			if err = ensureMTU(link, mtu); err != nil {
+				return err
+			}
+		}
 		err = ensureUpLink(link)
 		if err != nil {
 			return err
@@ -64,6 +70,11 @@ func EnsureNetDevice(link netlink.Link, eri *types.ERI) error {
 		return nil
 	} else {
 		// if interface is already up, don't config it to avoid traffic disruption, just check it's addr
+		if eri.JumboFrame {
+			if err = ensureMTU(link, mtu); err != nil {
+				return err
+			}
+		}
 		addrList, err := netlink.AddrList(link, netlink.FAMILY_V4)
 		if err != nil {
 			return err
@@ -79,6 +90,13 @@ func EnsureNetDevice(link netlink.Link, eri *types.ERI) error {
 		}
 		return nil
 	}
+}
+
+func ensureMTU(link netlink.Link, mtu int) error {
+	if link.Attrs().MTU == mtu {
+		return nil
+	}
+	return netlink.LinkSetMTU(link, mtu)
 }
 
 func ensureUpLink(link netlink.Link) error {

--- a/internal/types/eri.go
+++ b/internal/types/eri.go
@@ -3,12 +3,14 @@ package types
 import "strings"
 
 type ERI struct {
-	ID           string
-	IsPrimaryENI bool
-	MAC          string
-	InstanceID   string
-	CardIndex    int
-	QueuePair    int
+	ID            string
+	IsPrimaryENI  bool
+	MAC           string
+	InstanceID    string
+	CardIndex     int
+	QueuePair     int
+	JumboFrame    bool
+	JumboFrameMTU int
 }
 
 type ERdmaCAP uint32


### PR DESCRIPTION
## Summary

- Query `DescribeInstanceAttribute` ECS API to detect whether the instance has jumbo frame (`EnableJumboFrame`) enabled
- Propagate the result through the `ERdmaDevice` CR spec (`jumboFrame` field) from controller to agent
- Agent configures MTU on ERDMA network interfaces via `netlink.LinkSetMTU` when jumbo frame is enabled
- MTU value defaults to 8500 but is configurable via `--jumbo-frame-mtu` agent flag (also exposed in Helm `values.yaml`)
- CRD schema change is additive and backwards-compatible: existing CRs remain valid with `jumboFrame: false` (no MTU change = old behavior preserved)

## Changes

| File | Change |
|------|--------|
| `api/v1/erdmadevice_types.go` | Add `JumboFrame bool` to `ERdmaDeviceSpec` |
| `internal/types/eri.go` | Add `JumboFrame bool`, `JumboFrameMTU int` to `ERI` |
| `internal/controller/eri.go` | Add `IsJumboFrameEnabled()` calling `DescribeInstanceAttribute`; extract `jumboFrameFromAttr()` helper |
| `internal/controller/node_controller.go` | Query jumbo frame status when creating `ERdmaDevice` CR |
| `internal/agent/agent.go` | Pass `JumboFrame` / `JumboFrameMTU` from CR spec to each `ERI` |
| `internal/drivers/mtu.go` | Platform-independent `jumboMTU()` helper + `defaultJumboFrameMTU` constant |
| `internal/drivers/netdev.go` | Call `ensureMTU(link, mtu)` before bringing interface up and when already up |
| `cmd/agent/main.go` | Add `--jumbo-frame-mtu` flag (default 8500) |
| `deploy/helm/` | Update CRD template, `values.yaml`, and DaemonSet to expose `jumboFrameMTU` |
| `config/crd/bases/` | Update CRD manifest with `jumboFrame` field |

## Test plan

- [x] `TestJumboMTU`: MTU selection logic — default fallback (0→8500), custom value, negative value edge case
- [x] `TestDefaultJumboFrameMTU`: pins constant to 8500
- [x] `TestJumboFrameFromAttr`: nil/true/false pointer cases for `DescribeInstanceAttribute` response field
- [x] All existing tests pass (`TestSelectEriFromExist`, `TestSelectEriNoManagedExists`, `TestNodeReconciler_OwnNode`, `TestPredictNodeUpdate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)