### PR TITLE
bump default erdma-installer-version to 1.5.9

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -32,7 +32,7 @@ func main() {
 		"Only manager on-node eri resources without using OpenAPI and access key")
 	flag.StringVar(&exposedLocalERIs, "exposed-local-eris", "",
 		"allocate specific ERI from existing ERI to pods for each instance")
-	flag.StringVar(&erdmaInstallerVersion, "erdma-installer-version", "1.5.4",
+	flag.StringVar(&erdmaInstallerVersion, "erdma-installer-version", "1.5.9",
 		"erdma installer version")
 	flag.Parse()
 


### PR DESCRIPTION
## Summary
- Bump the default value of the `--erdma-installer-version` agent flag from `1.5.4` to `1.5.9`.

## Test plan
- [x] Confirm agent starts with the new default and pulls erdma-installer 1.5.9.
- [x] Verify users can still override via `--erdma-installer-version` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)